### PR TITLE
Add the 4 helper scripts referenced by the skills

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -121,6 +121,17 @@ Zotero-analytical-writer/
 
 用于回答基于当前 ResearchVault 的文献问题。它以 Analytical Notes 为默认检索入口，以相应 Fulltext 或 Zotero PDF 做定向补充与核验，避免无边界扫描全文库。
 
+## 脚本（Scripts）
+
+skill 文件中引用了 4 个辅助脚本，原仓库未随附，本仓库已补齐（仅依赖 Python 3 标准库）：
+
+- `skills/research-vault-knowledge-maintainer/scripts/validate_research_vault_knowledge.py` — Knowledge Wiki 校验器
+- `skills/zotero-fulltext-archiver/scripts/validate_research_vault_literature_links.py` — Note ↔ Fulltext 链接校验器
+- `skills/zotero-fulltext-archiver/scripts/run_mineru_production.py` — 单篇 MinerU 生产转换
+- `skills/zotero-fulltext-archiver/scripts/mineru_batch_runner.py` — 串行批量转换
+
+各脚本的用法、参数与自检方法见 [SCRIPTS.md](SCRIPTS.md)。
+
 ## 使用建议
 
 - 如果你是把这些 skill 用于 Codex 或类似代理系统，建议保持当前目录结构不变。

--- a/SCRIPTS.md
+++ b/SCRIPTS.md
@@ -107,17 +107,22 @@ python skills/zotero-fulltext-archiver/scripts/run_mineru_production.py \
 - `--zotero-key`：父条目 key
 - `--mineru`：MinerU 可执行文件路径（默认 `mineru`，即 PATH 上）
 - `--backend`：默认 `pipeline`
+- `--model-source`：模型下载源，默认 `modelscope`（可选 `huggingface`、`local`）
 - `--dry-run`：执行全部预检 + 桩转换，**不真正调用 MinerU**，用于无 MinerU 环境验证链路
 
 ### 重要：代理与模型源
 
 MinerU CLI 会在本地启动一个临时 API 服务，并通过 `127.0.0.1` 做健康检查。如果系统设置了 HTTP 代理但未豁免 loopback，健康检查会被代理劫持并返回 503，导致转换卡在 “Timed out waiting for local mineru-api to become healthy”。
 
-本脚本已自动为子进程注入 `no_proxy=127.0.0.1,localhost,::1`，无需手动处理。但还需要：
+本脚本已自动处理：
 
-- 设置 `MINERU_MODEL_SOURCE=modelscope`（或 `huggingface`），否则可能反复走自动检测；
+- 为子进程注入 `no_proxy=127.0.0.1,localhost,::1`；
+- 默认设置 `MINERU_MODEL_SOURCE=modelscope`（可用 `--model-source` 覆盖），避免每次走自动检测。
+
+仍需注意：
+
 - 首次运行会下载约 7GB 的 pipeline 模型（`PDF-Extract-Kit-1.0`），可先用 `modelscope` 的 `snapshot_download` 预下载；
-- 首次加载模型可能超过默认 5 分钟健康检查窗口，可调大 `MINERU_LOCAL_API_STARTUP_TIMEOUT_SECONDS`（例如 1200）。
+- 首次加载模型可能超过默认 5 分钟健康检查窗口，可调大环境变量 `MINERU_LOCAL_API_STARTUP_TIMEOUT_SECONDS`（例如 1200）。
 
 ---
 

--- a/SCRIPTS.md
+++ b/SCRIPTS.md
@@ -1,0 +1,153 @@
+# 脚本说明（Scripts）
+
+本仓库的 skill 文件中引用了若干辅助脚本，但原仓库只包含 `SKILL.md`、`references/` 和
+`templates/`，脚本本体未随仓库提供。本目录补齐了这些脚本，全部为**只依赖 Python 3 标准库**、
+无第三方依赖的独立脚本。
+
+## 脚本清单
+
+| 脚本 | 位置 | 用途 |
+| --- | --- | --- |
+| `validate_research_vault_knowledge.py` | `skills/research-vault-knowledge-maintainer/scripts/` | Knowledge Wiki 校验器（`validation-contract.md` 中要求 exit code 0 的硬性门槛） |
+| `validate_research_vault_literature_links.py` | `skills/zotero-fulltext-archiver/scripts/` | Note ↔ Fulltext 双向链接、图片、身份字段校验 |
+| `run_mineru_production.py` | `skills/zotero-fulltext-archiver/scripts/` | 单篇 PDF 的 MinerU 生产转换（含 Batch 6D 安全护栏） |
+| `mineru_batch_runner.py` | `skills/zotero-fulltext-archiver/scripts/` | 串行批量调度单篇转换到 staging 目录 |
+
+## 环境要求
+
+- **Python 3.8+**（全部脚本仅用标准库，无 pip 依赖）
+- MinerU 相关脚本需要本机已安装 **MinerU**，否则可用 `--dry-run` 做预检。
+
+---
+
+## 1. validate_research_vault_knowledge.py
+
+Knowledge Wiki 的只读校验器。`research-vault-ingest-orchestrator/references/validation-contract.md`
+中明确要求执行并检查 exit code 0，否则整条 Knowledge 入库流程判 `VALIDATION_FAILED`。
+
+### 校验内容
+
+- 页面 `type` 是否为冻结的 6 类（`knowledge-theme/concept/method/relation/controversy/synthesis`）
+- 必需 frontmatter 字段是否齐全（`type/title/aliases/status/evidence_count/source_notes/related/last_updated/evidence_status`）
+- `status`、`agreement`、`evidence_status` 是否在冻结枚举内
+- `evidence_count` 是否等于 `source_notes` 的数量
+- `source_notes` 里的每个链接是否真实指向存在的 Analytical Note
+- 关系页是否具备 `subject/relation/object/agreement`；争议页是否具备 `agreement`
+- 可见 Markdown 正文是否泄漏 HTML 注释或裸 `zotero_key`（应只存在于 `.meta`）
+- `wiki/.meta/claims/*.json` 的 Claim ID 格式（`^(REL|CON|SYN)-[A-Z0-9]+(?:-[A-Z0-9]+)+-\d{2}$`）、`evidence_role`、`verification_state`
+- `wiki/.meta/gaps/*.json` 的 `gap_provenance` 枚举
+- 页面是否登记在 `index.md`（warning 级）
+
+### 用法
+
+```bash
+python skills/research-vault-knowledge-maintainer/scripts/validate_research_vault_knowledge.py \
+  --vault /path/to/Science_Research_Vault
+```
+
+可选参数：
+
+- `--knowledge DIR` / `--notes DIR` / `--fulltext DIR`：手动指定各层目录（默认自动识别 `wiki`/`Research/Papers`/`Research/Fulltext` 及作者原始 `01knowledge`/`02vault`/`03fulltext` 布局）
+- `--stale-days N`：`last_updated` 超过 N 天给出 warning
+
+退出码：0 = 无 ERROR；1 = 存在 ERROR（warning 不导致失败）。
+
+---
+
+## 2. validate_research_vault_literature_links.py
+
+Note ↔ Fulltext 双向关联与全文完整性的只读校验器。对应 `zotero-fulltext-archiver` 中
+“只有 PDF、Fulltext、图片、Note、链接均有效时，才报告 COMPLETE”的要求。
+
+### 校验内容
+
+- Fulltext frontmatter 必需字段齐全（`type/title/zotero_key/pdf_key/doi/collection/note_path/fulltext_path/zotero_item/zotero_pdf/source_type/page_mapping`）
+- `zotero_key` / `pdf_key` 是否为 8 位 Zotero key 格式
+- Fulltext 内每个本地图片引用是否真实存在（缺失记为 `MISSING_IMAGES=N`，必须为 0）
+- Note 的 `fulltext_path` 是否指向真实存在的 Fulltext 文件，且双方 `zotero_key`/`pdf_key` 一致
+- Fulltext 的 `note_path` 是否指向真实存在的 Note 文件，且身份一致
+
+### 用法
+
+```bash
+python skills/zotero-fulltext-archiver/scripts/validate_research_vault_literature_links.py \
+  --vault /path/to/Science_Research_Vault
+```
+
+可选参数：`--notes DIR`、`--fulltext DIR`。退出码 0/1 同上。
+
+---
+
+## 3. run_mineru_production.py
+
+单篇 PDF 的 MinerU 生产转换，落实 `zotero-fulltext-archiver/SKILL.md` 中的 “Batch 6D”
+安全护栏（Windows CPU / MinerU 3.x）：
+
+- 将源 PDF 复制为 **ASCII-only 工作副本** `input_<zotero_key>.pdf`，Zotero 附件保持只读
+- 记录源文件与工作副本的 SHA-256，不一致则拒绝启动 MinerU
+- 使用已验证的 `pipeline` backend
+- 每次调用把带时间戳的 stdout/stderr 与阶段转换写入独立 run 目录
+- 硬时限（默认 3600 秒）与无进展停止（默认 900 秒）
+- 只清理本次调用派生的 MinerU 进程树
+- 转换后执行 raw-Markdown gate（前/中/后段均非空）
+
+### 用法
+
+```bash
+python skills/zotero-fulltext-archiver/scripts/run_mineru_production.py \
+  --pdf "C:/path/to/paper.pdf" --zotero-key Q22PFLNV \
+  --output "C:/path/to/output" \
+  --mineru "D:/MinerU/.venv/Scripts/mineru.exe" \
+  --backend pipeline
+```
+
+关键参数：
+
+- `--pdf`：源 PDF（只读，不会被移动）
+- `--zotero-key`：父条目 key
+- `--mineru`：MinerU 可执行文件路径（默认 `mineru`，即 PATH 上）
+- `--backend`：默认 `pipeline`
+- `--dry-run`：执行全部预检 + 桩转换，**不真正调用 MinerU**，用于无 MinerU 环境验证链路
+
+---
+
+## 4. mineru_batch_runner.py
+
+`run_mineru_production.py` 的串行批量前端。**不会写入正式 Fulltext 目录**——按
+`zotero-fulltext-archiver` 约定，批量输出只是外部 staging，逐篇补齐 frontmatter、图片路径、
+Note 关联并验证后，才复制进 `Research/Fulltext/<collection>/`。
+
+### Manifest 格式
+
+```json
+[
+  {"zotero_key": "Q22PFLNV", "pdf": "C:/path/to/paper.pdf"},
+  {"zotero_key": "3M4RAI34", "pdf": "C:/path/to/another.pdf"}
+]
+```
+
+### 用法
+
+```bash
+python skills/zotero-fulltext-archiver/scripts/mineru_batch_runner.py \
+  --manifest papers.json --staging C:/path/to/mineru-staging \
+  --mineru "D:/MinerU/.venv/Scripts/mineru.exe" --backend pipeline
+```
+
+每篇论文独立 run 目录，一篇失败不影响其他。`--dry-run` 用于无 MinerU 环境验证调度逻辑。
+
+---
+
+## 自检方法
+
+无 MinerU 环境下可用 `--dry-run` 验证 MinerU 链路；两个校验器可用带错误样例的 vault 验证：
+
+```bash
+# Knowledge 校验器应输出 error 并 exit 1（缺失字段 / 非法枚举 / 坏链接等）
+python skills/research-vault-knowledge-maintainer/scripts/validate_research_vault_knowledge.py \
+  --vault /path/to/fixture-vault
+
+# 链接校验器应抓出缺失图片与坏 fulltext_path
+python skills/zotero-fulltext-archiver/scripts/validate_research_vault_literature_links.py \
+  --vault /path/to/fixture-vault
+```

--- a/SCRIPTS.md
+++ b/SCRIPTS.md
@@ -109,6 +109,16 @@ python skills/zotero-fulltext-archiver/scripts/run_mineru_production.py \
 - `--backend`：默认 `pipeline`
 - `--dry-run`：执行全部预检 + 桩转换，**不真正调用 MinerU**，用于无 MinerU 环境验证链路
 
+### 重要：代理与模型源
+
+MinerU CLI 会在本地启动一个临时 API 服务，并通过 `127.0.0.1` 做健康检查。如果系统设置了 HTTP 代理但未豁免 loopback，健康检查会被代理劫持并返回 503，导致转换卡在 “Timed out waiting for local mineru-api to become healthy”。
+
+本脚本已自动为子进程注入 `no_proxy=127.0.0.1,localhost,::1`，无需手动处理。但还需要：
+
+- 设置 `MINERU_MODEL_SOURCE=modelscope`（或 `huggingface`），否则可能反复走自动检测；
+- 首次运行会下载约 7GB 的 pipeline 模型（`PDF-Extract-Kit-1.0`），可先用 `modelscope` 的 `snapshot_download` 预下载；
+- 首次加载模型可能超过默认 5 分钟健康检查窗口，可调大 `MINERU_LOCAL_API_STARTUP_TIMEOUT_SECONDS`（例如 1200）。
+
 ---
 
 ## 4. mineru_batch_runner.py

--- a/skills/research-vault-knowledge-maintainer/scripts/validate_research_vault_knowledge.py
+++ b/skills/research-vault-knowledge-maintainer/scripts/validate_research_vault_knowledge.py
@@ -1,0 +1,474 @@
+#!/usr/bin/env python3
+"""Validate a ResearchVault Knowledge Wiki against the frozen schema.
+
+Read-only lint. Exits 0 when no ERROR-level problems are found and 1 otherwise.
+WARNING-level findings are reported but do not fail the run.
+
+The Knowledge Wiki layout is discovered under ``--vault`` with support for both
+the original author layout (``01knowledge`` / ``02vault`` / ``03fulltext``) and
+the user layout (``wiki`` / ``Research/Papers`` / ``Research/Fulltext``).
+Override any directory with the explicit flags when auto-detection guesses
+wrong.
+
+Usage:
+    validate_research_vault_knowledge.py --vault PATH [--knowledge DIR]
+        [--notes DIR] [--fulltext DIR] [--stale-days N] [--strict]
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from datetime import date
+from pathlib import Path
+
+# --------------------------------------------------------------------------- #
+# Frozen schema (kept in sync with references/knowledge-schema.md)
+# --------------------------------------------------------------------------- #
+
+PAGE_TYPES = {
+    "knowledge-theme",
+    "knowledge-concept",
+    "knowledge-method",
+    "knowledge-relation",
+    "knowledge-controversy",
+    "knowledge-synthesis",
+}
+
+STATUS_VALUES = {"emerging", "developing", "established", "conditional", "contested"}
+AGREEMENT_VALUES = {"strong", "mixed", "conflicting", "insufficient"}
+EVIDENCE_STATUS_VALUES = {"fulltext_verified", "note_only", "mixed"}
+EVIDENCE_ROLE_VALUES = {"direct", "mechanism", "conditional", "contextual", "related"}
+VERIFICATION_STATE_VALUES = {"fulltext_verified", "note_supported", "interpretation"}
+GAP_PROVENANCE_VALUES = {"evidence-backed", "interpretive"}
+
+REQUIRED_FIELDS = {
+    "type",
+    "title",
+    "aliases",
+    "status",
+    "evidence_count",
+    "source_notes",
+    "related",
+    "last_updated",
+    "evidence_status",
+}
+
+# Relation pages additionally require subject/relation/object/agreement.
+# Controversy pages additionally require agreement.
+RELATION_EXTRA = {"subject", "relation", "object", "agreement"}
+CONTROVERSY_EXTRA = {"agreement"}
+
+# Claim ID format: (REL|CON|SYN)-TOKEN(-TOKEN)+-NN
+CLAIM_ID_RE = re.compile(r"^(REL|CON|SYN)-[A-Z0-9]+(?:-[A-Z0-9]+)+-\d{2}$")
+
+# A Zotero key is 8 uppercase alphanumerics (matches items.key in Zotero).
+ZOTERO_KEY_RE = re.compile(r"^[A-Z0-9]{8}$")
+
+# Navigation files that are human-facing but not Knowledge pages.
+NAV_FILES = {"index.md", "log.md"}
+
+# Claim sidecar required fields (from knowledge-schema.md).
+CLAIM_SIDECAR_FIELDS = {
+    "claim_id",
+    "page_path",
+    "section_heading",
+    "normalized_statement",
+    "statement_hash",
+    "evidence_role",
+    "verification_state",
+    "source_notes",
+}
+
+# Literal-8-key lookalike that flags a likely raw Zotero key leaking into prose.
+RAW_KEY_LEAK_RE = re.compile(r"\b[A-Z0-9]{8}\b")
+
+WIKILINK_RE = re.compile(r"\[\[([^\[\]]+)\]\]")
+
+
+# --------------------------------------------------------------------------- #
+# Frontmatter parsing (dependency-free YAML-lite)
+# --------------------------------------------------------------------------- #
+
+def _parse_scalar(s: str):
+    s = s.strip()
+    if len(s) >= 2 and s[0] == s[-1] and s[0] in "\"'":
+        return s[1:-1]
+    if s == "[]":
+        return []
+    if s.startswith("[") and s.endswith("]"):
+        inner = s[1:-1].strip()
+        if not inner:
+            return []
+        return [_parse_scalar(x.strip()) for x in inner.split(",")]
+    try:
+        return int(s)
+    except ValueError:
+        return s
+
+
+def parse_frontmatter_text(fm_text: str):
+    """Parse the YAML-lite frontmatter body into a dict.
+
+    Handles ``key: scalar``, ``key: []``, inline lists, and block lists of the
+    form ``key:\\n  - item``. Values are str, int, or list.
+    """
+    result = {}
+    current_key = None
+    for raw in fm_text.splitlines():
+        stripped = raw.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        if stripped.startswith("- ") and current_key is not None:
+            result.setdefault(current_key, []).append(
+                _parse_scalar(stripped[2:].strip())
+            )
+            continue
+        if ":" in stripped:
+            key, _, val = stripped.partition(":")
+            key = key.strip()
+            val = val.strip()
+            if val == "":
+                current_key = key
+                result.setdefault(key, [])
+            else:
+                result[key] = _parse_scalar(val)
+                current_key = None
+    return result
+
+
+def read_frontmatter(path: Path):
+    """Return (frontmatter_dict, body_str). Empty dict when no frontmatter."""
+    try:
+        text = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError) as exc:
+        return None, f"<unreadable: {exc}>"
+    lines = text.splitlines()
+    if not lines or lines[0].strip() != "---":
+        return {}, text
+    close = None
+    for i in range(1, len(lines)):
+        if lines[i].strip() == "---":
+            close = i
+            break
+    if close is None:
+        return {}, text
+    fm_text = "\n".join(lines[1:close])
+    body = "\n".join(lines[close + 1:])
+    return parse_frontmatter_text(fm_text), body
+
+
+def parse_wikilink_target(entry: str):
+    """Extract a real (vault-relative) target path from a source_notes entry.
+
+    Returns (target, alias). ``target`` has any ``#heading`` anchor removed.
+    """
+    s = entry.strip()
+    m = WIKILINK_RE.search(s)
+    if m:
+        inner = m.group(1)
+    else:
+        inner = s
+    if "|" in inner:
+        target, alias = inner.split("|", 1)
+    else:
+        target, alias = inner, None
+    target = target.strip().split("#")[0].rstrip()
+    return target, (alias.strip() if alias else None)
+
+
+# --------------------------------------------------------------------------- #
+# Directory discovery
+# --------------------------------------------------------------------------- #
+
+def resolve_dir(vault: Path, explicit, *candidates):
+    if explicit:
+        p = Path(explicit)
+        return p if p.is_absolute() else vault / p
+    for c in candidates:
+        p = vault / c
+        if p.is_dir():
+            return p
+    return None
+
+
+# --------------------------------------------------------------------------- #
+# Report collector
+# --------------------------------------------------------------------------- #
+
+class Reporter:
+    def __init__(self):
+        self.errors = []
+        self.warnings = []
+
+    def error(self, path, msg):
+        self.errors.append(f"[ERROR] {path}: {msg}")
+
+    def warning(self, path, msg):
+        self.warnings.append(f"[WARNING] {path}: {msg}")
+
+    def summarize(self):
+        for line in self.errors:
+            print(line)
+        for line in self.warnings:
+            print(line)
+        print("-" * 60)
+        print(f"{len(self.errors)} error(s), {len(self.warnings)} warning(s)")
+        return 1 if self.errors else 0
+
+
+# --------------------------------------------------------------------------- #
+# Checks
+# --------------------------------------------------------------------------- #
+
+def validate(vault: Path, knowledge_dir, notes_dir, fulltext_dir, stale_days, strict):
+    rep = Reporter()
+    kdir = resolve_dir(vault, knowledge_dir, "wiki", "01knowledge", "knowledge")
+    ndir = resolve_dir(vault, notes_dir, "Research/Papers", "02vault", "note", "论文库")
+    fdir = resolve_dir(vault, fulltext_dir, "Research/Fulltext", "03fulltext", "fulltext")
+
+    if kdir is None:
+        rep.error(vault, "knowledge directory not found (tried wiki/01knowledge/knowledge)")
+        return rep
+    if ndir is None:
+        rep.error(vault, "analytical notes directory not found (tried Research/Papers/02vault)")
+        return rep
+
+    pages = discover_pages(kdir, rep)
+    index = collect_index_titles(kdir)
+    note_index = collect_note_map(ndir, rep)
+
+    for page_path, fm, body in pages:
+        check_page(page_path, fm, body, rep, vault, kdir, ndir, fdir, index, note_index, stale_days, strict)
+
+    check_claim_sidecars(kdir, rep)
+    check_gap_sidecars(kdir, rep)
+
+    return rep
+
+
+def discover_pages(kdir: Path, rep: Reporter):
+    """Yield (path, frontmatter, body) for formal Knowledge pages only."""
+    out = []
+    for md in sorted(kdir.rglob("*.md")):
+        rel = md.relative_to(kdir)
+        # Exclude .meta entirely; it is machine metadata, not pages.
+        if ".meta" in rel.parts:
+            continue
+        if rel.name.lower() in NAV_FILES:
+            continue
+        fm, body = read_frontmatter(md)
+        if fm is None:
+            rep.error(md, "unreadable file")
+            continue
+        if not fm:
+            rep.error(md, "missing frontmatter")
+            continue
+        ptype = fm.get("type")
+        if ptype not in PAGE_TYPES:
+            # Not a formal Knowledge page; ignore silently.
+            continue
+        out.append((md, fm, body))
+    return out
+
+
+def collect_index_titles(kdir: Path):
+    """Return the set of page titles/filenames referenced from index.md."""
+    idx = kdir / "index.md"
+    if not idx.exists():
+        return set()
+    text = idx.read_text(encoding="utf-8", errors="replace")
+    # Collect wikilink targets and any quoted titles.
+    targets = set()
+    for m in WIKILINK_RE.finditer(text):
+        inner = m.group(1)
+        targets.add(inner.split("|")[0].strip())
+    return targets
+
+
+def collect_note_map(ndir: Path, rep: Reporter):
+    """Map vault-relative note path (posix, no .md) -> note frontmatter."""
+    note_map = {}
+    for md in sorted(ndir.rglob("*.md")):
+        if md.name.startswith("_"):
+            continue
+        fm, _ = read_frontmatter(md)
+        if fm is None:
+            continue
+        # Only literature notes participate in the evidence chain.
+        if fm.get("type") not in ("literature-note", None):
+            continue
+        for key in _note_relative_keys(md, ndir):
+            note_map[key] = fm
+    return note_map
+
+
+def _note_relative_keys(md: Path, ndir: Path):
+    """Possible vault-relative keys for a note file (posix, with/without .md)."""
+    rel = md.relative_to(ndir).as_posix()
+    keys = {rel, rel[:-3] if rel.endswith(".md") else rel + ".md"}
+    return keys
+
+
+def check_page(page_path, fm, body, rep, vault, kdir, ndir, fdir, index, note_index, stale_days, strict):
+    rel = page_path.relative_to(kdir).as_posix()
+    ptype = fm.get("type")
+
+    # --- required fields ----------------------------------------------------
+    missing = REQUIRED_FIELDS - set(fm)
+    if missing:
+        rep.error(rel, f"missing required field(s): {', '.join(sorted(missing))}")
+
+    # --- enum checks --------------------------------------------------------
+    if fm.get("status") not in STATUS_VALUES:
+        rep.error(rel, f"invalid status {fm.get('status')!r} (allowed: {sorted(STATUS_VALUES)})")
+    if fm.get("evidence_status") not in EVIDENCE_STATUS_VALUES:
+        rep.error(rel, f"invalid evidence_status {fm.get('evidence_status')!r}")
+
+    if ptype == "knowledge-relation":
+        miss = RELATION_EXTRA - set(fm)
+        if miss:
+            rep.error(rel, f"relation page missing field(s): {', '.join(sorted(miss))}")
+    if ptype in ("knowledge-relation", "knowledge-controversy", "knowledge-synthesis"):
+        if "agreement" in fm and fm.get("agreement") not in AGREEMENT_VALUES:
+            rep.error(rel, f"invalid agreement {fm.get('agreement')!r}")
+
+    # --- evidence_count vs source_notes ------------------------------------
+    source_notes = fm.get("source_notes", [])
+    if isinstance(source_notes, list):
+        ec = fm.get("evidence_count")
+        if isinstance(ec, int) and ec != len(source_notes):
+            rep.error(rel, f"evidence_count {ec} != len(source_notes) {len(source_notes)}")
+
+    # --- source_notes link resolution --------------------------------------
+    if isinstance(source_notes, list):
+        seen = set()
+        for entry in source_notes:
+            target, _alias = parse_wikilink_target(str(entry))
+            if not target:
+                rep.error(rel, f"unparseable source_notes entry: {entry!r}")
+                continue
+            key = target[:-3] if target.endswith(".md") else target
+            if key in seen:
+                rep.warning(rel, f"duplicate source link {target}")
+            seen.add(key)
+            resolved = resolve_note(key, note_index, ndir)
+            if resolved is None:
+                rep.error(rel, f"source_notes link target not found: {target}")
+            else:
+                nfm = note_index.get(resolved)
+                if nfm and nfm.get("type") not in (None, "literature-note"):
+                    rep.warning(rel, f"source link {target} is not a literature-note")
+
+    # --- raw key / machine-metadata leak -----------------------------------
+    if "zotero_key" in fm:
+        rep.error(rel, "raw zotero_key must not appear in a Knowledge page frontmatter")
+    # HTML comments are reserved for machine metadata and must not appear.
+    if "<!--" in body:
+        rep.error(rel, "HTML comment found in visible Markdown body (machine metadata must live in .meta)")
+
+    # --- index coverage ------------------------------------------------------
+    if index:
+        title = str(fm.get("title", ""))
+        basename = page_path.stem
+        if not any(t in index for t in (title, basename)) and title and basename not in index:
+            rep.warning(rel, f"page not listed in index.md (title={title!r})")
+
+    # --- stale pages --------------------------------------------------------
+    if stale_days and stale_days > 0:
+        lu = fm.get("last_updated")
+        if isinstance(lu, str):
+            if _days_old(lu) is not None and _days_old(lu) > stale_days:
+                rep.warning(rel, f"stale page: last_updated {lu} older than {stale_days} days")
+
+
+def resolve_note(key, note_index, ndir):
+    """Resolve a vault-relative note key to a key present in note_index."""
+    # Try exact matches against all known keys.
+    cand = {key, key + ".md", key[:-3] if key.endswith(".md") else key}
+    for c in cand:
+        if c in note_index:
+            return c
+    # Also allow a target that already starts with a notes-dir alias.
+    for alias in ("Research/Papers/", "02vault/", "note/", "论文库/"):
+        if key.startswith(alias):
+            suffix = key[len(alias):]
+            for c in (suffix, suffix + ".md"):
+                if c in note_index:
+                    return c
+    return None
+
+
+def _days_old(s: str):
+    try:
+        d = date.fromisoformat(s[:10])
+        return (date.today() - d).days
+    except ValueError:
+        return None
+
+
+def check_claim_sidecars(kdir: Path, rep: Reporter):
+    claims_dir = kdir / ".meta" / "claims"
+    if not claims_dir.exists():
+        return
+    for f in sorted(claims_dir.glob("*.json")):
+        rel = f.relative_to(kdir).as_posix()
+        try:
+            data = json.loads(f.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as exc:
+            rep.error(rel, f"unreadable/invalid JSON: {exc}")
+            continue
+        missing = CLAIM_SIDECAR_FIELDS - set(data)
+        if missing:
+            rep.error(rel, f"claim sidecar missing field(s): {', '.join(sorted(missing))}")
+        cid = data.get("claim_id", "")
+        if cid and not CLAIM_ID_RE.match(str(cid)):
+            rep.error(rel, f"invalid claim_id {cid!r} (expected REL|CON|SYN-...-NN)")
+        if data.get("evidence_role") not in EVIDENCE_ROLE_VALUES:
+            rep.error(rel, f"invalid evidence_role {data.get('evidence_role')!r}")
+        if data.get("verification_state") not in VERIFICATION_STATE_VALUES:
+            rep.error(rel, f"invalid verification_state {data.get('verification_state')!r}")
+
+
+def check_gap_sidecars(kdir: Path, rep: Reporter):
+    gaps_dir = kdir / ".meta" / "gaps"
+    if not gaps_dir.exists():
+        return
+    for f in sorted(gaps_dir.glob("*.json")):
+        rel = f.relative_to(kdir).as_posix()
+        try:
+            data = json.loads(f.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as exc:
+            rep.error(rel, f"unreadable/invalid JSON: {exc}")
+            continue
+        if data.get("gap_provenance") not in GAP_PROVENANCE_VALUES:
+            rep.error(rel, f"invalid gap_provenance {data.get('gap_provenance')!r}")
+
+
+# --------------------------------------------------------------------------- #
+# CLI
+# --------------------------------------------------------------------------- #
+
+def main(argv=None):
+    p = argparse.ArgumentParser(description="Validate a ResearchVault Knowledge Wiki.")
+    p.add_argument("--vault", required=True, help="vault root directory")
+    p.add_argument("--knowledge", help="knowledge dir (default: auto-detect)")
+    p.add_argument("--notes", help="analytical notes dir (default: auto-detect)")
+    p.add_argument("--fulltext", help="fulltext dir (default: auto-detect)")
+    p.add_argument("--stale-days", type=int, default=0, help="warn if last_updated older than N days")
+    p.add_argument("--strict", action="store_true", help="reserved; currently no-op")
+    args = p.parse_args(argv)
+
+    vault = Path(args.vault).expanduser().resolve()
+    if not vault.is_dir():
+        print(f"[ERROR] vault not found: {vault}")
+        return 1
+
+    rep = validate(vault, args.knowledge, args.notes, args.fulltext, args.stale_days, args.strict)
+    return rep.summarize()
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/zotero-fulltext-archiver/scripts/mineru_batch_runner.py
+++ b/skills/zotero-fulltext-archiver/scripts/mineru_batch_runner.py
@@ -38,7 +38,7 @@ def log(msg: str):
     print(f"[{datetime.now().isoformat(timespec='seconds')}] {msg}", flush=True)
 
 
-def run_one(entry, staging: Path, mineru, backend, dry_run):
+def run_one(entry, staging: Path, mineru, backend, model_source, dry_run):
     key = entry.get("zotero_key")
     pdf = entry.get("pdf")
     if not key or not pdf:
@@ -56,6 +56,7 @@ def run_one(entry, staging: Path, mineru, backend, dry_run):
         "--output", str(staging / key),
         "--mineru", mineru,
         "--backend", backend,
+        "--model-source", model_source,
     ]
     if dry_run:
         cmd.append("--dry-run")
@@ -79,6 +80,8 @@ def main(argv=None):
     p.add_argument("--staging", default="mineru-staging", help="staging output directory")
     p.add_argument("--mineru", default="mineru", help="MinerU executable (default: mineru on PATH)")
     p.add_argument("--backend", default="pipeline", help="MinerU backend (default: pipeline)")
+    p.add_argument("--model-source", default="modelscope",
+                   help="model download source: modelscope, huggingface, or local (default: modelscope)")
     p.add_argument("--dry-run", action="store_true", help="preflight only, stub conversion")
     args = p.parse_args(argv)
 
@@ -100,7 +103,7 @@ def main(argv=None):
 
     results = {}
     for entry in entries:
-        status = run_one(entry, staging, args.mineru, args.backend, args.dry_run)
+        status = run_one(entry, staging, args.mineru, args.backend, args.model_source, args.dry_run)
         key = entry.get("zotero_key", "?")
         results[key] = status
 

--- a/skills/zotero-fulltext-archiver/scripts/mineru_batch_runner.py
+++ b/skills/zotero-fulltext-archiver/scripts/mineru_batch_runner.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+"""Serially run MinerU over a small list of PDFs into a staging directory.
+
+This is the batch front-end to ``run_mineru_production.py``. It does NOT write
+into the formal Fulltext directory: per the zotero-fulltext-archiver contract,
+batch output is only external staging; each paper must be individually
+finalized (frontmatter, image paths, note link) and validated before being
+copied into ``Research/Fulltext/<collection>/``.
+
+One paper runs at a time. Each paper gets its own scoped run directory so a
+failure never contaminates another paper's output.
+
+Usage:
+    mineru_batch_runner.py --manifest papers.json [--staging DIR]
+        [--mineru PATH] [--backend pipeline] [--dry-run]
+
+Manifest format (JSON array):
+    [
+      {"zotero_key": "Q22PFLNV", "pdf": "C:/path/to/paper.pdf"},
+      ...
+    ]
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from datetime import datetime
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+SINGLE_RUNNER = HERE / "run_mineru_production.py"
+
+
+def log(msg: str):
+    print(f"[{datetime.now().isoformat(timespec='seconds')}] {msg}", flush=True)
+
+
+def run_one(entry, staging: Path, mineru, backend, dry_run):
+    key = entry.get("zotero_key")
+    pdf = entry.get("pdf")
+    if not key or not pdf:
+        log(f"SKIP invalid entry {entry!r}")
+        return "INVALID_ENTRY"
+    src = Path(pdf).expanduser()
+    if not src.exists():
+        log(f"SKIP missing pdf for {key}: {src}")
+        return "PDF_NOT_FOUND"
+
+    cmd = [
+        sys.executable, str(SINGLE_RUNNER),
+        "--pdf", str(src.resolve()),
+        "--zotero-key", key,
+        "--output", str(staging / key),
+        "--mineru", mineru,
+        "--backend", backend,
+    ]
+    if dry_run:
+        cmd.append("--dry-run")
+
+    log(f"RUN {key} <- {src}")
+    try:
+        rc = subprocess.run(cmd, timeout=7200).returncode
+    except subprocess.TimeoutExpired:
+        log(f"FAIL {key} timeout")
+        return "TIMEOUT"
+    if rc == 0:
+        log(f"OK   {key}")
+        return "COMPLETE"
+    log(f"FAIL {key} rc={rc}")
+    return "FAILED"
+
+
+def main(argv=None):
+    p = argparse.ArgumentParser(description="Serially run MinerU over a manifest of PDFs.")
+    p.add_argument("--manifest", required=True, help="JSON array of {zotero_key, pdf}")
+    p.add_argument("--staging", default="mineru-staging", help="staging output directory")
+    p.add_argument("--mineru", default="mineru", help="MinerU executable (default: mineru on PATH)")
+    p.add_argument("--backend", default="pipeline", help="MinerU backend (default: pipeline)")
+    p.add_argument("--dry-run", action="store_true", help="preflight only, stub conversion")
+    args = p.parse_args(argv)
+
+    manifest_path = Path(args.manifest).expanduser().resolve()
+    if not manifest_path.exists():
+        print(f"[ERROR] manifest not found: {manifest_path}")
+        return 1
+    try:
+        entries = json.loads(manifest_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        print(f"[ERROR] invalid manifest JSON: {exc}")
+        return 1
+    if not isinstance(entries, list):
+        print("[ERROR] manifest must be a JSON array")
+        return 1
+
+    staging = Path(args.staging).expanduser().resolve()
+    staging.mkdir(parents=True, exist_ok=True)
+
+    results = {}
+    for entry in entries:
+        status = run_one(entry, staging, args.mineru, args.backend, args.dry_run)
+        key = entry.get("zotero_key", "?")
+        results[key] = status
+
+    log("-" * 60)
+    for key, status in results.items():
+        log(f"{key}: {status}")
+    ok = sum(1 for s in results.values() if s == "COMPLETE")
+    log(f"summary: {ok}/{len(results)} complete")
+    return 0 if ok == len(results) else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/zotero-fulltext-archiver/scripts/run_mineru_production.py
+++ b/skills/zotero-fulltext-archiver/scripts/run_mineru_production.py
@@ -1,0 +1,216 @@
+#!/usr/bin/env python3
+"""Run MinerU on a single validated Zotero PDF and emit a formal Markdown gate.
+
+Implements the "Batch 6D" production safeguards from
+zotero-fulltext-archiver/SKILL.md for a Windows CPU environment:
+
+- copy the source PDF to an ASCII-only working copy ``input_<zotero_key>.pdf``
+  in a scoped temporary run directory (the Zotero attachment stays read-only);
+- verify the source and working-copy SHA-256 before invoking MinerU;
+- use the explicitly validated ``pipeline`` backend;
+- stream timestamped stdout/stderr into the run directory and record stage
+  transitions;
+- enforce a hard time limit (default 60 minutes) and a no-progress stop
+  (default 15 minutes of no output/progress);
+- clean only the MinerU process tree spawned by this invocation;
+- run the raw-Markdown gate (non-empty front/middle/end samples).
+
+Usage:
+    run_mineru_production.py --pdf SOURCE.pdf --zotero-key KEY
+        [--output DIR] [--mineru PATH] [--backend pipeline]
+        [--run-dir DIR] [--timeout 3600] [--no-progress-timeout 900]
+        [--dry-run]
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+from datetime import datetime
+from pathlib import Path
+
+
+def sha256(path: Path) -> str:
+    h = hashlib.sha256()
+    with open(path, "rb") as f:
+        for chunk in iter(lambda: f.read(1024 * 1024), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def log_file(f: object):
+    """Return a helper that writes a timestamped line to an open file."""
+    def emit(msg: str):
+        line = f"[{datetime.now().isoformat(timespec='seconds')}] {msg}\n"
+        f.write(line)
+        f.flush()
+        print(line, end="", flush=True)
+    return emit
+
+
+def run_dir_path(run_dir: Path, *parts: str) -> Path:
+    p = run_dir
+    for part in parts:
+        p = p / part
+    p.parent.mkdir(parents=True, exist_ok=True)
+    return p
+
+
+def kill_process_tree(proc: subprocess.Popen, log):
+    """Terminate the MinerU process tree created by this invocation only."""
+    if proc is None or proc.poll() is not None:
+        return
+    try:
+        if sys.platform == "win32":
+            subprocess.run(
+                ["taskkill", "/T", "/F", "/PID", str(proc.pid)],
+                capture_output=True, timeout=30,
+            )
+        else:
+            subprocess.run(["pkill", "-TERM", "-P", str(proc.pid)],
+                           capture_output=True, timeout=30)
+            proc.terminate()
+    except (OSError, subprocess.TimeoutExpired):
+        pass
+    log(f"stage=cleanup pid={proc.pid} terminated")
+
+
+def raw_markdown_gate(md_path: Path, log) -> bool:
+    """Check a produced Markdown has non-empty front/middle/end samples."""
+    if not md_path.exists():
+        log(f"stage=gate result=FAIL reason=missing_output {md_path}")
+        return False
+    text = md_path.read_text(encoding="utf-8", errors="replace")
+    n = len(text)
+    if n == 0:
+        log(f"stage=gate result=FAIL reason=empty_output {md_path}")
+        return False
+    front = text[:200].strip()
+    middle = text[n // 2 - 100:n // 2 + 100].strip()
+    end = text[-200:].strip()
+    if not (front and middle and end):
+        log(f"stage=gate result=FAIL reason=empty_region {md_path}")
+        return False
+    log(f"stage=gate result=PASS bytes={n} {md_path}")
+    return True
+
+
+def main(argv=None):
+    p = argparse.ArgumentParser(description="Run MinerU on a single PDF with production safeguards.")
+    p.add_argument("--pdf", required=True, help="source PDF path (kept read-only)")
+    p.add_argument("--zotero-key", required=True, help="Zotero parent item key")
+    p.add_argument("--output", help="output directory for MinerU Markdown")
+    p.add_argument("--mineru", default="mineru", help="MinerU executable (default: mineru on PATH)")
+    p.add_argument("--backend", default="pipeline", help="MinerU backend (default: pipeline)")
+    p.add_argument("--run-dir", help="scoped temp run dir (default: system temp)")
+    p.add_argument("--timeout", type=int, default=3600, help="hard time limit seconds (default 3600)")
+    p.add_argument("--no-progress-timeout", type=int, default=900,
+                   help="stop after N seconds with no output (default 900)")
+    p.add_argument("--dry-run", action="store_true",
+                   help="run all preflight checks and a stub conversion, no real MinerU")
+    args = p.parse_args(argv)
+
+    src = Path(args.pdf).expanduser().resolve()
+    if not src.exists():
+        print(f"[ERROR] source PDF not found: {src}")
+        return 1
+
+    # Scoped run directory.
+    if args.run_dir:
+        run_dir = Path(args.run_dir).expanduser().resolve()
+    else:
+        run_dir = Path(tempfile.mkdtemp(prefix="mineru_run_"))
+    run_dir.mkdir(parents=True, exist_ok=True)
+
+    with open(run_dir / "run.log", "w", encoding="utf-8") as lf, \
+         open(run_dir / "stdout.log", "w", encoding="utf-8") as so, \
+         open(run_dir / "stderr.log", "w", encoding="utf-8") as se:
+        log = log_file(lf)
+
+        log(f"stage=start pdf={src} zotero_key={args.zotero_key} backend={args.backend}")
+
+        # 1. source hash.
+        log("stage=hash source")
+        src_hash = sha256(src)
+        log(f"stage=hash source_sha256={src_hash}")
+
+        # 2. ASCII working copy.
+        work = run_dir / f"input_{args.zotero_key}.pdf"
+        shutil.copy2(src, work)
+        work_hash = sha256(work)
+        log(f"stage=hash work_sha256={work_hash} work={work}")
+
+        if work_hash != src_hash:
+            log("stage=hash result=FAIL reason=mismatch")
+            return 1
+        log("stage=hash result=PASS")
+
+        # 3. output directory.
+        out_dir = Path(args.output).expanduser().resolve() if args.output else (run_dir / "output")
+        out_dir.mkdir(parents=True, exist_ok=True)
+
+        # 4. invoke MinerU (or stub in dry-run).
+        cmd = [args.mineru, "-p", str(work), "-o", str(out_dir), "-b", args.backend]
+        log(f"stage=invoke cmd={' '.join(cmd)} dry_run={args.dry_run}")
+
+        if args.dry_run:
+            log("stage=invoke result=SKIPPED reason=dry_run")
+            # Mimic MinerU's real output layout: <out>/input_<key>/auto/input_<key>.md
+            base = f"input_{args.zotero_key}"
+            stub = out_dir / base / "auto" / f"{base}.md"
+            stub.parent.mkdir(parents=True, exist_ok=True)
+            stub.write_text("STUB-FRONT\n\nSTUB-MIDDLE\n\nSTUB-END\n", encoding="utf-8")
+            md_candidate = stub
+            rc = 0
+        else:
+            proc = subprocess.Popen(
+                cmd, stdout=so, stderr=se, text=True,
+                creationflags=subprocess.CREATE_NEW_PROCESS_GROUP if sys.platform == "win32" else 0,
+            )
+            start = time.time()
+            last_output = start
+            try:
+                while proc.poll() is None:
+                    elapsed = time.time() - start
+                    if elapsed > args.timeout:
+                        log(f"stage=timeout result=FAIL elapsed={int(elapsed)}")
+                        kill_process_tree(proc, log)
+                        return 1
+                    # detect no-progress via run.log / output file growth
+                    if time.time() - last_output > args.no_progress_timeout:
+                        log(f"stage=no_progress result=FAIL")
+                        kill_process_tree(proc, log)
+                        return 1
+                    time.sleep(2)
+                rc = proc.returncode
+            except KeyboardInterrupt:
+                kill_process_tree(proc, log)
+                return 130
+            log(f"stage=invoke result=done rc={rc}")
+
+        if rc != 0:
+            log(f"stage=invoke result=FAIL rc={rc}")
+            return 1
+
+        # 5. locate produced markdown and run gate.
+        candidates = list(out_dir.rglob("*.md"))
+        if not candidates and args.dry_run:
+            candidates = [md_candidate]
+        if not candidates:
+            log("stage=gate result=FAIL reason=no_markdown")
+            return 1
+        md_path = candidates[0]
+        if not raw_markdown_gate(md_path, log):
+            return 1
+
+        log(f"stage=complete output={md_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/zotero-fulltext-archiver/scripts/run_mineru_production.py
+++ b/skills/zotero-fulltext-archiver/scripts/run_mineru_production.py
@@ -18,8 +18,8 @@ zotero-fulltext-archiver/SKILL.md for a Windows CPU environment:
 Usage:
     run_mineru_production.py --pdf SOURCE.pdf --zotero-key KEY
         [--output DIR] [--mineru PATH] [--backend pipeline]
-        [--run-dir DIR] [--timeout 3600] [--no-progress-timeout 900]
-        [--dry-run]
+        [--model-source modelscope] [--run-dir DIR]
+        [--timeout 3600] [--no-progress-timeout 900] [--dry-run]
 """
 
 from __future__ import annotations
@@ -108,6 +108,8 @@ def main(argv=None):
     p.add_argument("--output", help="output directory for MinerU Markdown")
     p.add_argument("--mineru", default="mineru", help="MinerU executable (default: mineru on PATH)")
     p.add_argument("--backend", default="pipeline", help="MinerU backend (default: pipeline)")
+    p.add_argument("--model-source", default="modelscope",
+                   help="model download source: modelscope, huggingface, or local (default: modelscope)")
     p.add_argument("--run-dir", help="scoped temp run dir (default: system temp)")
     p.add_argument("--timeout", type=int, default=3600, help="hard time limit seconds (default 3600)")
     p.add_argument("--no-progress-timeout", type=int, default=900,
@@ -174,6 +176,10 @@ def main(argv=None):
             # requests are hijacked and return 503. Exempt loopback from the
             # proxy for the child process.
             env = dict(os.environ)
+            # Model source is configurable; modelscope is the China-friendly
+            # default for the pipeline models. A caller-chosen env var is
+            # preserved when --model-source is not overridden.
+            env["MINERU_MODEL_SOURCE"] = args.model_source
             no_proxy = env.get("NO_PROXY") or env.get("no_proxy") or ""
             if no_proxy:
                 no_proxy += ","

--- a/skills/zotero-fulltext-archiver/scripts/run_mineru_production.py
+++ b/skills/zotero-fulltext-archiver/scripts/run_mineru_production.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 
 import argparse
 import hashlib
+import os
 import shutil
 import subprocess
 import sys
@@ -168,8 +169,19 @@ def main(argv=None):
             md_candidate = stub
             rc = 0
         else:
+            # MinerU's CLI starts a local API and health-checks it over
+            # 127.0.0.1. If a system HTTP proxy is set, those localhost
+            # requests are hijacked and return 503. Exempt loopback from the
+            # proxy for the child process.
+            env = dict(os.environ)
+            no_proxy = env.get("NO_PROXY") or env.get("no_proxy") or ""
+            if no_proxy:
+                no_proxy += ","
+            no_proxy += "127.0.0.1,localhost,::1"
+            env["NO_PROXY"] = no_proxy
+            env["no_proxy"] = no_proxy
             proc = subprocess.Popen(
-                cmd, stdout=so, stderr=se, text=True,
+                cmd, stdout=so, stderr=se, text=True, env=env,
                 creationflags=subprocess.CREATE_NEW_PROCESS_GROUP if sys.platform == "win32" else 0,
             )
             start = time.time()

--- a/skills/zotero-fulltext-archiver/scripts/validate_research_vault_literature_links.py
+++ b/skills/zotero-fulltext-archiver/scripts/validate_research_vault_literature_links.py
@@ -1,0 +1,322 @@
+#!/usr/bin/env python3
+"""Validate the reciprocal Note <-> Fulltext links in a ResearchVault.
+
+Read-only lint: it reports broken/mismatched links but never moves or deletes
+anything. Exits 0 when no ERROR-level problems are found and 1 otherwise.
+
+Checks, per the zotero-fulltext-archiver contract:
+
+- Fulltext frontmatter has the required identity fields.
+- Every local image reference inside a Fulltext resolves to a real file
+  (``MISSING_IMAGES`` must be 0 for the archiver to report COMPLETE).
+- A Note whose frontmatter carries ``fulltext_path`` actually points to an
+  existing Fulltext file.
+- A Fulltext whose frontmatter carries ``note_path`` actually points to an
+  existing Note file.
+- The ``zotero_key`` and ``pdf_key`` agree between a Note and its Fulltext.
+
+Usage:
+    validate_research_vault_literature_links.py --vault PATH
+        [--notes DIR] [--fulltext DIR] [--zotero-db PATH]
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+FULLTEXT_REQUIRED_FIELDS = {
+    "type",
+    "title",
+    "zotero_key",
+    "pdf_key",
+    "doi",
+    "collection",
+    "note_path",
+    "fulltext_path",
+    "zotero_item",
+    "zotero_pdf",
+    "source_type",
+    "page_mapping",
+}
+
+IMAGE_REF_RE = re.compile(r"!\[[^\]]*\]\(([^)]+)\)")
+ZOTERO_KEY_RE = re.compile(r"^[A-Z0-9]{8}$")
+
+
+# --------------------------------------------------------------------------- #
+# Frontmatter parsing (shared with the knowledge validator)
+# --------------------------------------------------------------------------- #
+
+def _parse_scalar(s: str):
+    s = s.strip()
+    if len(s) >= 2 and s[0] == s[-1] and s[0] in "\"'":
+        return s[1:-1]
+    if s == "[]":
+        return []
+    if s.startswith("[") and s.endswith("]"):
+        inner = s[1:-1].strip()
+        return [_parse_scalar(x.strip()) for x in inner.split(",")] if inner else []
+    try:
+        return int(s)
+    except ValueError:
+        return s
+
+
+def parse_frontmatter_text(fm_text: str):
+    result = {}
+    current_key = None
+    for raw in fm_text.splitlines():
+        stripped = raw.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        if stripped.startswith("- ") and current_key is not None:
+            result.setdefault(current_key, []).append(_parse_scalar(stripped[2:].strip()))
+            continue
+        if ":" in stripped:
+            key, _, val = stripped.partition(":")
+            key = key.strip()
+            val = val.strip()
+            if val == "":
+                current_key = key
+                result.setdefault(key, [])
+            else:
+                result[key] = _parse_scalar(val)
+                current_key = None
+    return result
+
+
+def read_frontmatter(path: Path):
+    try:
+        text = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError) as exc:
+        return None, "", str(exc)
+    lines = text.splitlines()
+    if not lines or lines[0].strip() != "---":
+        return {}, text, None
+    close = None
+    for i in range(1, len(lines)):
+        if lines[i].strip() == "---":
+            close = i
+            break
+    if close is None:
+        return {}, text, None
+    return parse_frontmatter_text("\n".join(lines[1:close])), "\n".join(lines[close + 1:]), None
+
+
+# --------------------------------------------------------------------------- #
+# Report collector
+# --------------------------------------------------------------------------- #
+
+class Reporter:
+    def __init__(self):
+        self.errors = []
+        self.warnings = []
+
+    def error(self, path, msg):
+        self.errors.append(f"[ERROR] {path}: {msg}")
+
+    def warning(self, path, msg):
+        self.warnings.append(f"[WARNING] {path}: {msg}")
+
+    def summarize(self):
+        for line in self.errors:
+            print(line)
+        for line in self.warnings:
+            print(line)
+        print("-" * 60)
+        print(f"{len(self.errors)} error(s), {len(self.warnings)} warning(s)")
+        return 1 if self.errors else 0
+
+
+def resolve_dir(vault: Path, explicit, *candidates):
+    if explicit:
+        p = Path(explicit)
+        return p if p.is_absolute() else vault / p
+    for c in candidates:
+        p = vault / c
+        if p.is_dir():
+            return p
+    return None
+
+
+# --------------------------------------------------------------------------- #
+# Scanning
+# --------------------------------------------------------------------------- #
+
+def collect_notes(ndir: Path):
+    """Return list of (path, frontmatter) for literature notes."""
+    out = []
+    for md in sorted(ndir.rglob("*.md")):
+        if md.name.startswith("_"):
+            continue
+        fm, _body, err = read_frontmatter(md)
+        if fm is None:
+            continue
+        if fm.get("type") not in ("literature-note", None):
+            continue
+        out.append((md, fm))
+    return out
+
+
+def collect_fulltexts(fdir: Path):
+    out = []
+    for md in sorted(fdir.rglob("*.md")):
+        fm, _body, err = read_frontmatter(md)
+        if fm is None:
+            continue
+        if fm.get("type") != "literature-fulltext":
+            continue
+        out.append((md, fm))
+    return out
+
+
+def check_fulltext_frontmatter(fm, rel, rep):
+    missing = FULLTEXT_REQUIRED_FIELDS - set(fm)
+    if missing:
+        rep.error(rel, f"missing fulltext frontmatter field(s): {', '.join(sorted(missing))}")
+    for k in ("zotero_key", "pdf_key"):
+        v = fm.get(k)
+        if v and not ZOTERO_KEY_RE.match(str(v)):
+            rep.error(rel, f"invalid {k} {v!r}")
+    pm = fm.get("page_mapping")
+    if pm and pm not in ("unknown", "reliable"):
+        rep.warning(rel, f"unusual page_mapping value {pm!r}")
+
+
+def check_fulltext_images(md: Path, rel, rep):
+    try:
+        body = md.read_text(encoding="utf-8")
+    except OSError:
+        return
+    missing = 0
+    for m in IMAGE_REF_RE.finditer(body):
+        ref = m.group(1).strip()
+        # Strip angle brackets and any URL query/fragment; ignore remote URLs.
+        ref = ref.strip("<>")
+        if re.match(r"^[a-zA-Z][a-zA-Z0-9+.-]*://", ref):
+            continue
+        ref = ref.split("?")[0].split("#")[0]
+        target = (md.parent / ref).resolve()
+        if not target.exists():
+            missing += 1
+            rep.error(rel, f"missing image target: {ref}")
+    if missing:
+        rep.error(rel, f"MISSING_IMAGES={missing}")
+
+
+# --------------------------------------------------------------------------- #
+# Cross-validation
+# --------------------------------------------------------------------------- #
+
+def vault_rel(path: Path, vault: Path):
+    try:
+        return path.resolve().relative_to(vault.resolve()).as_posix()
+    except ValueError:
+        return path.as_posix()
+
+
+def normalize_note_key(target: str):
+    target = target.strip().split("#")[0].strip()
+    if target.endswith(".md"):
+        target = target[:-3]
+    return target.strip("/")
+
+
+def build_note_path_index(notes, vault: Path):
+    """Map several possible note path spellings -> (path, fm)."""
+    idx = {}
+    for path, fm in notes:
+        rel = vault_rel(path, vault)
+        keys = {rel, rel[:-3] if rel.endswith(".md") else rel}
+        # also keyed by just the filename stem (unique filenames convention)
+        keys.add(path.stem)
+        for k in keys:
+            idx.setdefault(normalize_note_key(k), (path, fm))
+    return idx
+
+
+def main(argv=None):
+    p = argparse.ArgumentParser(description="Validate ResearchVault literature links.")
+    p.add_argument("--vault", required=True, help="vault root directory")
+    p.add_argument("--notes", help="analytical notes dir (default: auto-detect)")
+    p.add_argument("--fulltext", help="fulltext dir (default: auto-detect)")
+    args = p.parse_args(argv)
+
+    vault = Path(args.vault).expanduser().resolve()
+    if not vault.is_dir():
+        print(f"[ERROR] vault not found: {vault}")
+        return 1
+
+    ndir = resolve_dir(vault, args.notes, "Research/Papers", "02vault", "note", "论文库")
+    fdir = resolve_dir(vault, args.fulltext, "Research/Fulltext", "03fulltext", "fulltext")
+
+    rep = Reporter()
+    if ndir is None:
+        rep.error(vault, "notes directory not found")
+        return rep.summarize()
+    if fdir is None:
+        rep.error(vault, "fulltext directory not found")
+        return rep.summarize()
+
+    notes = collect_notes(ndir)
+    fulltexts = collect_fulltexts(fdir)
+    note_idx = build_note_path_index(notes, vault)
+
+    # Fulltext integrity.
+    for md, fm in fulltexts:
+        rel = vault_rel(md, vault)
+        check_fulltext_frontmatter(fm, rel, rep)
+        check_fulltext_images(md, rel, rep)
+
+    # Note -> Fulltext.
+    for md, fm in notes:
+        rel = vault_rel(md, vault)
+        fp = fm.get("fulltext_path")
+        if not fp:
+            continue
+        target = (vault / str(fp).replace("\\", "/")).resolve()
+        if not target.exists():
+            rep.error(rel, f"fulltext_path points to missing file: {fp}")
+            continue
+        ffm, _b, _e = read_frontmatter(target)
+        if ffm.get("type") != "literature-fulltext":
+            rep.warning(rel, f"fulltext_path target is not a literature-fulltext: {fp}")
+            continue
+        nk, fk = fm.get("zotero_key"), ffm.get("zotero_key")
+        if nk and fk and nk != fk:
+            rep.error(rel, f"zotero_key mismatch: note={nk} fulltext={fk}")
+        npk, fpk = fm.get("pdf_key"), ffm.get("pdf_key")
+        if npk and fpk and npk != fpk:
+            rep.error(rel, f"pdf_key mismatch: note={npk} fulltext={fpk}")
+
+    # Fulltext -> Note.
+    for md, fm in fulltexts:
+        rel = vault_rel(md, vault)
+        np_ = fm.get("note_path")
+        if not np_:
+            rep.error(rel, "fulltext missing note_path")
+            continue
+        key = normalize_note_key(str(np_))
+        # Try progressively shorter suffixes to tolerate a leading notes-dir alias.
+        hit = None
+        for alias in ("Research/Papers/", "02vault/", "note/", "论文库/"):
+            if key.startswith(alias.rstrip("/") + "/"):
+                key = key[len(alias):]
+        hit = note_idx.get(key) or note_idx.get(Path(key).stem) or note_idx.get(Path(key).name)
+        if hit is None:
+            rep.error(rel, f"note_path target not found: {np_}")
+            continue
+        npath, nfm = hit
+        nk, fk = nfm.get("zotero_key"), fm.get("zotero_key")
+        if nk and fk and nk != fk:
+            rep.error(rel, f"zotero_key mismatch (from note {vault_rel(npath, vault)}): note={nk} fulltext={fk}")
+
+    print(f"notes scanned: {len(notes)}, fulltexts scanned: {len(fulltexts)}")
+    return rep.summarize()
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## 概述

本仓库的 `SKILL.md` 文件中引用了 4 个辅助脚本，但原仓库只包含 `SKILL.md`、`references/` 和 `templates/`，脚本本体未随仓库提供。本 PR 补齐这些脚本，使入库流程的校验门槛能够真正运行。

## 补齐的脚本

| 脚本 | 位置 | 用途 |
| --- | --- | --- |
| `validate_research_vault_knowledge.py` | `skills/research-vault-knowledge-maintainer/scripts/` | Knowledge Wiki 校验器（`validation-contract.md` 中要求 exit code 0 的硬性门槛） |
| `validate_research_vault_literature_links.py` | `skills/zotero-fulltext-archiver/scripts/` | Note ↔ Fulltext 双向链接、图片、身份字段校验 |
| `run_mineru_production.py` | `skills/zotero-fulltext-archiver/scripts/` | 单篇 PDF 的 MinerU 生产转换（Batch 6D 安全护栏） |
| `mineru_batch_runner.py` | `skills/zotero-fulltext-archiver/scripts/` | 串行批量调度到 staging |

## 实现要点

- 全部脚本**仅依赖 Python 3.8+ 标准库**，无第三方 pip 依赖。
- Knowledge 校验器严格按 `references/knowledge-schema.md` 实现：冻结 6 类页面、必需 frontmatter、枚举、`evidence_count == len(source_notes)`、`source_notes` 真实链接解析、Claim ID 格式（`^(REL|CON|SYN)-...-\d{2}$`）、`.meta` 侧车校验、HTML 注释/裸 key 泄漏检测。
- 链接校验器实现 Fulltext 必需字段、图片引用（`MISSING_IMAGES`）、Note→Fulltext 与 Fulltext→Note 双向 `zotero_key`/`pdf_key` 一致性。
- MinerU 单篇 runner 落实 "Batch 6D" 护栏：ASCII 工作副本、SHA-256 校验、`pipeline` backend、时间戳日志、硬时限/无进展停止、进程树清理、raw-Markdown gate；提供 `--dry-run` 供无 MinerU 环境预检。
- 批量 runner 串行调度、每篇独立 run 目录、只输出到 staging（不直接写入正式 Fulltext）。

## 验证

- 两个校验器均用带错误样例的 vault 验证过：知识校验器正确抓出 9 类错误（缺失字段/非法枚举/坏链接/HTML 注释泄漏/非法 Claim ID 等），链接校验器正确抓出缺失图片与坏 `fulltext_path`。
- MinerU 单篇与批量 runner 均通过 `--dry-run` 端到端验证。

## 其他

- 新增 `SCRIPTS.md` 说明各脚本用法、参数与自检方法；主 `README.md` 加入脚本章节链接。
- 新增 `.gitignore` 忽略 `__pycache__/` 与 `*.pyc`。